### PR TITLE
feat: masonry gallery with lightbox and category tabs

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,12 @@ const config: Config = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
+    // CSS and style imports
+    "\\.css$": "<rootDir>/src/__mocks__/fileMock.js",
+    // yet-another-react-lightbox — mock the full module for tests
+    "^yet-another-react-lightbox(.*)$": "<rootDir>/src/__mocks__/lightboxMock.tsx",
+    // react-masonry-css — mock to avoid ESM issues
+    "^react-masonry-css$": "<rootDir>/src/__mocks__/masonryMock.tsx",
   },
   testMatch: ["**/__tests__/**/*.test.tsx", "**/__tests__/**/*.test.ts"],
   transform: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "react-masonry-css": "^1.0.16",
+        "yet-another-react-lightbox": "^3.29.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2911,7 +2913,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2921,7 +2923,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4401,7 +4403,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -9257,6 +9259,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-masonry-css": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/react-masonry-css/-/react-masonry-css-1.0.16.tgz",
+      "integrity": "sha512-KSW0hR2VQmltt/qAa3eXOctQDyOu7+ZBevtKgpNDSzT7k5LA/0XntNa9z9HKCdz3QlxmJHglTZ18e4sX4V8zZQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -11183,6 +11194,32 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yet-another-react-lightbox": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/yet-another-react-lightbox/-/yet-another-react-lightbox-3.29.1.tgz",
+      "integrity": "sha512-0cpa+wlleiy2cWNjS9qrcY0+SgZQH/4PDx2uupLMI9Ofip1f7pCgZ95PlVp/EsFsO4ufwOTea51bkLhcEXJJSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/igordanchenko"
+      },
+      "peerDependencies": {
+        "@types/react": "^16 || ^17 || ^18 || ^19",
+        "@types/react-dom": "^16 || ^17 || ^18 || ^19",
+        "react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "react-masonry-css": "^1.0.16",
+    "yet-another-react-lightbox": "^3.29.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/__mocks__/fileMock.js
+++ b/src/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/src/__mocks__/lightboxMock.tsx
+++ b/src/__mocks__/lightboxMock.tsx
@@ -1,0 +1,23 @@
+// Mock yet-another-react-lightbox for tests
+import React from "react"
+
+interface LightboxProps {
+  open: boolean
+  index: number
+  close: () => void
+  slides: Array<{ src: string; alt?: string }>
+}
+
+function Lightbox({ open, slides, index }: LightboxProps) {
+  if (!open) return null
+  return (
+    <div data-testid="lightbox" role="dialog" aria-label="Image lightbox">
+      {slides[index] && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={slides[index].src} alt={slides[index].alt ?? ""} />
+      )}
+    </div>
+  )
+}
+
+export default Lightbox

--- a/src/__mocks__/masonryMock.tsx
+++ b/src/__mocks__/masonryMock.tsx
@@ -1,0 +1,15 @@
+// Mock react-masonry-css for tests — renders children directly
+import React from "react"
+
+interface MasonryProps {
+  children: React.ReactNode
+  breakpointCols?: number | Record<string, number>
+  className?: string
+  columnClassName?: string
+}
+
+function Masonry({ children }: MasonryProps) {
+  return <div data-testid="masonry-grid">{children}</div>
+}
+
+export default Masonry

--- a/src/__tests__/components.test.tsx
+++ b/src/__tests__/components.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import Nav from "@/components/Nav"
 import Hero from "@/components/Hero"
 import Gallery from "@/components/Gallery"
@@ -53,7 +53,7 @@ describe("Gallery", () => {
     render(<Gallery />)
     expect(screen.getByText("The Work")).toBeInTheDocument()
   })
-  it("renders 12 gallery images", () => {
+  it("renders 12 images by default (All tab)", () => {
     render(<Gallery />)
     const images = screen.getAllByRole("img")
     expect(images.length).toBe(12)
@@ -62,6 +62,42 @@ describe("Gallery", () => {
     render(<Gallery />)
     const images = screen.getAllByRole("img") as HTMLImageElement[]
     expect(images[0].src).toContain("picsum.photos")
+  })
+  it("renders category tabs", () => {
+    render(<Gallery />)
+    expect(screen.getByRole("tab", { name: /All/i })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /Portraits/i })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /Families/i })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /Events/i })).toBeInTheDocument()
+  })
+  it("All tab is selected by default", () => {
+    render(<Gallery />)
+    expect(screen.getByRole("tab", { name: /All/i })).toHaveAttribute("aria-selected", "true")
+  })
+  it("filters to portraits when Portraits tab is clicked", () => {
+    render(<Gallery />)
+    fireEvent.click(screen.getByRole("tab", { name: /Portraits/i }))
+    expect(screen.getByRole("tab", { name: /Portraits/i })).toHaveAttribute("aria-selected", "true")
+    // Portraits: 7 images in our data
+    const images = screen.getAllByRole("img")
+    expect(images.length).toBe(7)
+  })
+  it("filters to families when Families tab is clicked", () => {
+    render(<Gallery />)
+    fireEvent.click(screen.getByRole("tab", { name: /Families/i }))
+    const images = screen.getAllByRole("img")
+    expect(images.length).toBe(3)
+  })
+  it("filters to events when Events tab is clicked", () => {
+    render(<Gallery />)
+    fireEvent.click(screen.getByRole("tab", { name: /Events/i }))
+    const images = screen.getAllByRole("img")
+    expect(images.length).toBe(2)
+  })
+  it("renders lightbox trigger buttons with aria-labels", () => {
+    render(<Gallery />)
+    const buttons = screen.getAllByRole("button", { name: /Open .* in lightbox/i })
+    expect(buttons.length).toBe(12)
   })
 })
 

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,20 +1,63 @@
-// Varied seeds and dimensions to simulate a natural masonry feel
-const GALLERY_IMAGES = [
-  { seed: "ks-g1", w: 600, h: 800, alt: "Portrait session" },
-  { seed: "ks-g2", w: 600, h: 600, alt: "Family moment" },
-  { seed: "ks-g3", w: 600, h: 900, alt: "Outdoor portrait" },
-  { seed: "ks-g4", w: 600, h: 700, alt: "Natural light portrait" },
-  { seed: "ks-g5", w: 600, h: 600, alt: "Event photography" },
-  { seed: "ks-g6", w: 600, h: 800, alt: "Lifestyle session" },
-  { seed: "ks-g7", w: 600, h: 650, alt: "Family portrait" },
-  { seed: "ks-g8", w: 600, h: 900, alt: "Golden hour portrait" },
-  { seed: "ks-g9", w: 600, h: 700, alt: "Candid moment" },
-  { seed: "ks-g10", w: 600, h: 600, alt: "Studio portrait" },
-  { seed: "ks-g11", w: 600, h: 800, alt: "Outdoor family" },
-  { seed: "ks-g12", w: 600, h: 750, alt: "Portrait close-up" },
+"use client"
+
+import { useState } from "react"
+import Masonry from "react-masonry-css"
+import Lightbox from "yet-another-react-lightbox"
+import "yet-another-react-lightbox/styles.css"
+
+export type GalleryCategory = "all" | "portraits" | "families" | "events"
+
+export interface GalleryImage {
+  seed: string
+  w: number
+  h: number
+  alt: string
+  category: Exclude<GalleryCategory, "all">
+}
+
+export const GALLERY_IMAGES: GalleryImage[] = [
+  { seed: "ks-g1", w: 600, h: 800, alt: "Portrait session", category: "portraits" },
+  { seed: "ks-g2", w: 600, h: 600, alt: "Family moment", category: "families" },
+  { seed: "ks-g3", w: 600, h: 900, alt: "Outdoor portrait", category: "portraits" },
+  { seed: "ks-g4", w: 600, h: 700, alt: "Natural light portrait", category: "portraits" },
+  { seed: "ks-g5", w: 600, h: 600, alt: "Event photography", category: "events" },
+  { seed: "ks-g6", w: 600, h: 800, alt: "Lifestyle session", category: "portraits" },
+  { seed: "ks-g7", w: 600, h: 650, alt: "Family portrait", category: "families" },
+  { seed: "ks-g8", w: 600, h: 900, alt: "Golden hour portrait", category: "portraits" },
+  { seed: "ks-g9", w: 600, h: 700, alt: "Candid moment", category: "events" },
+  { seed: "ks-g10", w: 600, h: 600, alt: "Studio portrait", category: "portraits" },
+  { seed: "ks-g11", w: 600, h: 800, alt: "Outdoor family", category: "families" },
+  { seed: "ks-g12", w: 600, h: 750, alt: "Portrait close-up", category: "portraits" },
 ]
 
+const CATEGORIES: { value: GalleryCategory; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "portraits", label: "Portraits" },
+  { value: "families", label: "Families" },
+  { value: "events", label: "Events" },
+]
+
+const MASONRY_BREAKPOINTS = {
+  default: 3,
+  1024: 2,
+  640: 1,
+}
+
 export default function Gallery() {
+  const [activeCategory, setActiveCategory] = useState<GalleryCategory>("all")
+  const [lightboxIndex, setLightboxIndex] = useState(-1)
+
+  const filtered = GALLERY_IMAGES.filter(
+    (img) => activeCategory === "all" || img.category === activeCategory
+  )
+
+  const lightboxSlides = filtered.map((img) => ({
+    src: `https://picsum.photos/seed/${img.seed}/${img.w}/${img.h}`,
+    alt: img.alt,
+    width: img.w,
+    height: img.h,
+  }))
+
   return (
     <section id="gallery" className="py-24 px-6" style={{ backgroundColor: "#fafaf8" }}>
       <div className="max-w-6xl mx-auto">
@@ -22,31 +65,62 @@ export default function Gallery() {
           Portfolio
         </p>
         <h2
-          className="text-center text-3xl md:text-4xl text-stone-700 mb-12"
+          className="text-center text-3xl md:text-4xl text-stone-700 mb-8"
           style={{ fontFamily: "var(--font-playfair)" }}
         >
           The Work
         </h2>
 
-        {/* 3-column grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {GALLERY_IMAGES.map((img) => (
-            <div
+        {/* Category tabs */}
+        <div role="tablist" className="flex justify-center gap-1 mb-10">
+          {CATEGORIES.map((cat) => (
+            <button
+              key={cat.value}
+              role="tab"
+              aria-selected={activeCategory === cat.value}
+              onClick={() => setActiveCategory(cat.value)}
+              className={`px-5 py-2 text-xs tracking-widest uppercase transition-colors rounded-sm ${
+                activeCategory === cat.value
+                  ? "bg-stone-800 text-white"
+                  : "text-stone-500 hover:text-stone-800 border border-stone-200 hover:border-stone-400"
+              }`}
+            >
+              {cat.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Masonry grid */}
+        <Masonry
+          breakpointCols={MASONRY_BREAKPOINTS}
+          className="flex gap-4"
+          columnClassName="flex flex-col gap-4"
+        >
+          {filtered.map((img, idx) => (
+            <button
               key={img.seed}
-              className="group relative overflow-hidden rounded-sm"
+              onClick={() => setLightboxIndex(idx)}
+              className="group relative overflow-hidden rounded-sm w-full cursor-pointer focus:outline-none focus:ring-2 focus:ring-rose-300"
+              aria-label={`Open ${img.alt} in lightbox`}
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={`https://picsum.photos/seed/${img.seed}/${img.w}/${img.h}`}
                 alt={img.alt}
-                className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
-                style={{ aspectRatio: `${img.w}/${img.h}` }}
+                className="w-full h-auto block transition-transform duration-500 group-hover:scale-105"
               />
-              {/* Subtle hover overlay */}
               <div className="absolute inset-0 bg-white/0 group-hover:bg-white/10 transition-colors duration-300" />
-            </div>
+            </button>
           ))}
-        </div>
+        </Masonry>
+
+        {/* Lightbox */}
+        <Lightbox
+          open={lightboxIndex >= 0}
+          index={lightboxIndex}
+          close={() => setLightboxIndex(-1)}
+          slides={lightboxSlides}
+        />
       </div>
     </section>
   )


### PR DESCRIPTION
Closes #2

## What's built

- **Masonry layout** (react-masonry-css): images at natural aspect ratios — 3 col desktop, 2 tablet, 1 mobile
- **Lightbox** (yet-another-react-lightbox): click any image → full-screen overlay, prev/next buttons + arrow keys, Escape to close
- **Category tabs**: All | Portraits | Families | Events — instant filter, no page reload
- Images typed as `GalleryImage` with `{ seed, w, h, alt, category }` — easy to swap real photos in

## Tests

32 tests (was 26). New tests cover:
- Category tab rendering and aria-selected state
- Filtering: Portraits (7), Families (3), Events (2)
- Lightbox trigger buttons with aria-labels

Mocks added for lightbox and masonry so tests run without ESM/CSS issues.